### PR TITLE
Use rust.sysroot option

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -79,6 +79,10 @@ export class RLSConfiguration {
     return this.configuration.get('rust-client.rustupPath', 'rustup');
   }
 
+  public get sysroot(): string {
+    return this.configuration.get('rust.sysroot', '');
+  }
+
   public get useWSL(): boolean {
     return this.configuration.get<boolean>('rust-client.useWSL', false);
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -385,18 +385,22 @@ class ClientWorkspace {
     const env = { ...process.env };
 
     let sysroot: string | undefined;
-    try {
-      sysroot = await this.getSysroot(env);
-    } catch (err) {
-      console.info(err.message);
-      console.info(`Let's retry with extended $PATH`);
-      env.PATH = `${env.HOME || '~'}/.cargo/bin:${env.PATH || ''}`;
+    if (this.config.sysroot !== '') {
+      sysroot = this.config.sysroot;
+    } else {
       try {
         sysroot = await this.getSysroot(env);
-      } catch (e) {
-        console.warn('Error reading sysroot (second try)', e);
-        window.showWarningMessage(`Error reading sysroot: ${e.message}`);
-        return env;
+      } catch (err) {
+        console.info(err.message);
+        console.info(`Let's retry with extended $PATH`);
+        env.PATH = `${env.HOME || '~'}/.cargo/bin:${env.PATH || ''}`;
+        try {
+          sysroot = await this.getSysroot(env);
+        } catch (e) {
+          console.warn('Error reading sysroot (second try)', e);
+          window.showWarningMessage(`Error reading sysroot: ${e.message}`);
+          return env;
+        }
       }
     }
 


### PR DESCRIPTION
Rls has a `sysroot` option. rls-vscode also has the `sysroot` option. It seems that when we set the `sysroot` option in the vs-code rls, then the value should be delivered to the rls, but it was not.

Before this PR, rls-vscode wasn't using the sysroot option; instead, it was calculating the sysroot value by running `rustc --print sysroot` command.

In this PR, I changed the rls-vscode to use the sysroot value in the option. If a user doesn't set the sysroot option, vscode rls calculate the sysroot value using the `rustc --print sysroot` command.

This PR fixes #473.