### PR TITLE
Add tasks.json Support

### DIFF
--- a/fixtures/.vscode/tasks.json
+++ b/fixtures/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cargo",
+			"command": "build",
+			"args": [
+				"--target",
+				"x86_64-pc-windows-gnu"
+			],
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "custom build task"
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -115,14 +115,31 @@
         "taskDefinitions": [
             {
                 "type": "cargo",
-                "properties": {
-                    "subcommand": {
-                        "type": "string"
-                    }
-                },
                 "required": [
-                    "subcommand"
-                ]
+                    "command"
+                ],
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "command": {
+                        "type": "string"
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "env": {
+                        "type": "object",
+                        "patternProperties": {
+                            ".+": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
             }
         ],
         "problemMatchers": [

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -2,12 +2,12 @@ import {
   Disposable,
   ShellExecution,
   Task,
+  TaskDefinition,
   TaskGroup,
   TaskProvider,
   tasks,
   workspace,
   WorkspaceFolder,
-  TaskDefinition,
 } from 'vscode';
 
 /**

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -7,7 +7,7 @@ import {
   tasks,
   workspace,
   WorkspaceFolder,
-  TaskDefinition
+  TaskDefinition,
 } from 'vscode';
 
 /**
@@ -80,7 +80,10 @@ export function activateTaskProvider(target: WorkspaceFolder): Disposable {
   return tasks.registerTaskProvider(TASK_TYPE, provider);
 }
 
-function resolveCargoTask(task: Task, target: WorkspaceFolder): Task | undefined {
+function resolveCargoTask(
+  task: Task,
+  target: WorkspaceFolder,
+): Task | undefined {
   const definition = task.definition as CargoTaskDefinition;
 
   if (definition.type === 'cargo' && definition.command) {
@@ -92,7 +95,7 @@ function resolveCargoTask(task: Task, target: WorkspaceFolder): Task | undefined
       task.name,
       TASK_SOURCE,
       new ShellExecution('cargo', args, definition),
-      task.problemMatchers ?? ['$rustc']
+      task.problemMatchers ?? ['$rustc'],
     );
   }
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -104,18 +104,18 @@ function resolveCargoTask(
 
 function detectCargoTasks(target: WorkspaceFolder): Task[] {
   return [
-    { subcommand: 'build', group: TaskGroup.Build },
-    { subcommand: 'check', group: TaskGroup.Build },
-    { subcommand: 'test', group: TaskGroup.Test },
-    { subcommand: 'clean', group: TaskGroup.Clean },
-    { subcommand: 'run', group: undefined },
+    { command: 'build', group: TaskGroup.Build },
+    { command: 'check', group: TaskGroup.Build },
+    { command: 'test', group: TaskGroup.Test },
+    { command: 'clean', group: TaskGroup.Clean },
+    { command: 'run', group: undefined },
   ]
-    .map(({ subcommand, group }) => ({
-      definition: { subcommand, type: TASK_TYPE },
-      label: `cargo ${subcommand} - ${target.name}`,
+    .map(({ command, group }) => ({
+      definition: { command, type: TASK_TYPE },
+      label: `cargo ${command} - ${target.name}`,
       execution: createShellExecution({
         command: 'cargo',
-        args: [subcommand],
+        args: [command],
         cwd: target.uri.fsPath,
       }),
       group,

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -26,13 +26,54 @@ suite('Extension Tests', () => {
     ].map(path => Uri.file(path).fsPath);
 
     const expected = [
-      { subcommand: 'build', group: vscode.TaskGroup.Build, cwd: projects[0] },
-      { subcommand: 'build', group: vscode.TaskGroup.Build, cwd: projects[1] },
-      { subcommand: 'check', group: vscode.TaskGroup.Build, cwd: projects[0] },
-      { subcommand: 'check', group: vscode.TaskGroup.Build, cwd: projects[1] },
-      { subcommand: 'test', group: vscode.TaskGroup.Test, cwd: projects[1] },
-      { subcommand: 'clean', group: vscode.TaskGroup.Clean, cwd: projects[1] },
-      { subcommand: 'run', group: undefined, cwd: projects[1] },
+      {
+        command: 'build',
+        group: vscode.TaskGroup.Build,
+        cwd: projects[0],
+        name: 'cargo build - bare-lib-project',
+      },
+      {
+        command: 'build',
+        group: vscode.TaskGroup.Build,
+        cwd: projects[1],
+        name: 'cargo build - another-lib-project',
+      },
+      {
+        command: 'check',
+        group: vscode.TaskGroup.Build,
+        cwd: projects[0],
+        name: 'cargo check - bare-lib-project',
+      },
+      {
+        command: 'check',
+        group: vscode.TaskGroup.Build,
+        cwd: projects[1],
+        name: 'cargo check - another-lib-project',
+      },
+      {
+        command: 'test',
+        group: vscode.TaskGroup.Test,
+        cwd: projects[1],
+        name: 'cargo test - another-lib-project',
+      },
+      {
+        command: 'clean',
+        group: vscode.TaskGroup.Clean,
+        cwd: projects[1],
+        name: 'cargo clean - another-lib-project',
+      },
+      {
+        command: 'run',
+        group: undefined,
+        cwd: projects[1],
+        name: 'cargo run - another-lib-project',
+      },
+      {
+        command: 'build',
+        group: vscode.TaskGroup.Build,
+        cwd: '${workspaceFolder}',
+        name: 'custom build task',
+      },
     ];
 
     const whenWorkspacesActive = projects.map(path =>
@@ -75,7 +116,7 @@ suite('Extension Tests', () => {
 /** Fetches current VSCode tasks' partial objects for ease of assertion */
 async function fetchBriefTasks(): Promise<
   Array<{
-    subcommand: string;
+    command: string;
     group: vscode.TaskGroup | undefined;
     cwd?: string;
   }>
@@ -83,8 +124,9 @@ async function fetchBriefTasks(): Promise<
   const tasks = await vscode.tasks.fetchTasks();
 
   return tasks.map(task => ({
-    subcommand: task.definition.subcommand,
+    command: task.definition.command,
     group: task.group,
+    name: task.name,
     cwd:
       ((task.execution instanceof vscode.ProcessExecution ||
         task.execution instanceof vscode.ShellExecution) &&


### PR DESCRIPTION
`resolveTask` is now used by VSCode to resolve a task.json task to an execution. This commit adds support for this functionality, by porting changes made to the RA plugin: https://github.com/rust-analyzer/rust-analyzer/pull/4096

The `cargo` type should now work in the same way to other languages available in VSCode. E.g.

```json
{
	"type": "cargo",
	"command": "build",
	"args": [
		"--target",
		"x86_64-pc-windows-gnu"
	],
	"problemMatcher": [
		"$rustc"
	],
	"group": {
		"kind": "build",
		"isDefault": true
	},
	"label": "rust: cargo build1"
}
```