### PR TITLE
Fix: respect `rust-client.disableRustup` setting when using rust-anyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
                 "rust-client.disableRustup": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Disable usage of rustup and use rustc/rls from PATH."
+                    "description": "Disable usage of rustup and use rustc/rls/rust-analyzer from PATH."
                 },
                 "rust-client.channel": {
                     "anyOf": [

--- a/src/rustAnalyzer.ts
+++ b/src/rustAnalyzer.ts
@@ -216,8 +216,11 @@ export async function createLanguageClient(
     rustAnalyzer: { path?: string; releaseTag: string };
   },
 ): Promise<lc.LanguageClient> {
-  await rustup.ensureToolchain(config.rustup);
-  await rustup.ensureComponents(config.rustup, REQUIRED_COMPONENTS);
+  if (!config.rustup.disabled) {
+    await rustup.ensureToolchain(config.rustup);
+    await rustup.ensureComponents(config.rustup, REQUIRED_COMPONENTS);
+  }
+
   if (!config.rustAnalyzer.path) {
     await getServer({
       askBeforeDownload: true,


### PR DESCRIPTION
Currently `rust-analyzer` fails to start if `rustup` is missing even if it's disabled in the settings