### PR TITLE
rust-analyzer: Listen for new "roots scanned" message to indicate progress

### DIFF
--- a/src/rustAnalyzer.ts
+++ b/src/rustAnalyzer.ts
@@ -285,7 +285,7 @@ async function setupGlobalProgress(client: lc.LanguageClient) {
     if (newState === lc.State.Starting) {
       await client.onReady();
 
-      const RUST_ANALYZER_PROGRESS = 'rustAnalyzer/startup';
+      const RUST_ANALYZER_PROGRESS = 'rustAnalyzer/roots scanned';
       client.onProgress(
         new lc.ProgressType<{
           kind: 'begin' | 'report' | 'end';


### PR DESCRIPTION
As of rust-analyzer/rust-analyzer@dad1333b48c3, the `rustAnalyzer/startup` message has been replaced with a functionally-equivalent[1] `rustAnalyzer/roots scanned` message. Since we're still looking for the old message, which is no longer sent at all, our progress UI hangs on "Starting" when using rust-analyzer. Listen for the new message instead to fix this.

[1] At least, it appears functionally equivalent to me, but I don't know anything about rust-analyzer's internals so I could be wrong.