### PR TITLE
Temporarily ignore rust-analyzer/ wrt. formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# FIXME: Only ignore the pending changes to be merged into this extension
+rust-analyzer/


### PR DESCRIPTION
So the CI stays green during the transition period.