### PR TITLE
Remove angular brackets from `autoClosingPairs`

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -13,7 +13,6 @@
        { "open": "{", "close": "}" },
        { "open": "[", "close": "]" },
        { "open": "(", "close": ")" },
-       { "open": "<", "close": ">" },
        { "open": "\"", "close": "\"", "notIn": ["string"] },
        { "open": "/**", "close": " */", "notIn": ["string"] },
        { "open": "/*!", "close": " */", "notIn": ["string"] }


### PR DESCRIPTION
Angular brackets were added to `autoClosingPairs` in #720 on the premise that Rust developers write generics more than comparison logic. While this might be true, this causes issues when writing comparisons, because you get situations like this:
```rust
if (x <>
       ^ automatically added
```
This issue has been discussed [here](https://github.com/rust-lang/vscode-rust/issues/798), [here](https://github.com/rust-lang/vscode-rust/issues/798), and [here](https://stackoverflow.com/questions/64942734/how-do-i-disable-automatic-closing-of-without-disabling-it-for-other-brackets/64973407#64973407). This PR removes angular brackets from `autoClosingPairs` as recommended by vscode to avoid any ambiguity.