### PR TITLE
Add task support for cargo-watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,12 @@
                         "line": 3,
                         "column": 4
                     }
-                ]
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^\\[Running",
+                    "endsPattern": "^\\[Finished running"
+                }
             }
         ],
         "configuration": {

--- a/src/cargo.ts
+++ b/src/cargo.ts
@@ -1,0 +1,80 @@
+import * as child_process from 'child_process';
+import * as util from 'util';
+import * as vscode from 'vscode';
+import { runTaskCommand } from './tasks';
+import { startSpinner, stopSpinner } from './spinner';
+
+const exec = util.promisify(child_process.exec);
+
+interface Package {
+  readonly name: string;
+  readonly version: string;
+}
+
+export async function ensurePackage(name: string): Promise<boolean> {
+  if (await isPackageInstalled(name)) {
+    return true;
+  }
+
+  const ok = await Promise.resolve(
+    vscode.window.showInformationMessage(
+      `The package ${name} is required. Install it?`,
+      'Yes',
+    ),
+  );
+
+  if (!ok) {
+    throw new Error(`Missing package ${name}`);
+  }
+
+  return await installPackage(name);
+}
+
+export async function isPackageInstalled(name: string): Promise<boolean> {
+  const packages = await listInstalledPackages();
+  return packages.some(p => p.name === name);
+}
+
+async function listInstalledPackages(): Promise<Package[]> {
+  const { stdout } = await exec(`cargo install --list`, { encoding: 'utf8' });
+
+  const result: Package[] = [];
+  const regex = /^(?<name>\S+) v(?<version>[^:]+):$/gm;
+  let match: RegExpMatchArray | null;
+
+  while ((match = regex.exec(stdout)) && match.groups) {
+    result.push({
+      name: match.groups.name,
+      version: match.groups.version,
+    });
+  }
+
+  return result;
+}
+
+async function installPackage(name: string): Promise<boolean> {
+  startSpinner(`Installing ${name}...`);
+
+  try {
+    const command = 'cargo';
+    const args = ['install', name];
+    await runTaskCommand({ command, args }, `Installing \`${name}\``);
+
+    if (!(await isPackageInstalled(name))) {
+      throw new Error(`Failed to detect package ${name}`);
+    }
+
+    stopSpinner(`Installed ${name}`);
+    return true;
+  } catch (e) {
+    stopSpinner(`Could not install ${name}`);
+
+    vscode.window.showErrorMessage(
+      `Could not install package: ${name}${
+        e.message ? `, message: ${e.message}` : ''
+      }`,
+    );
+
+    throw e;
+  }
+}


### PR DESCRIPTION
Given the popularity of [`cargo-watch`](https://github.com/watchexec/cargo-watch), it is benefitial is this extension does somewhat help with watch tasks.

Aside from adding `background` definition to the `$rustc` problem matcher, this PR also adds some `cargo` util methods as well as automatic detection and running of a `watch` task.

The 4 combinations of either having `cargo-watch` installed and having a `watch` task defined in `.vscode/tasks.json` have been considered:

- If `cargo-watch` isn't installed and no `watch` task is defined in `tasks.json`, no `watch` task will be automatically suggested. It would be fantastic if we could suggest a `watch` task and propose to install `cargo-watch` whenever the user picked it, but I wasn't able to figure out how to do that.
- If `cargo-watch` isn't installed but a `watch` task is defined in `tasks.json`, the user will be prompted to install `cargo-watch`, in case it's missing.
- If `cargo-watch` is installed and no `watch` task is defined in `tasks.json`, there will be an automatic `watch` task suggestion.
- If `cargo-watch` is installed and a `watch` task is defined in `tasks.json`, everything just works.

Hopefully this comes in handy for other people.