### PR TITLE
make auto completion of single quotation possible

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -15,6 +15,7 @@
        { "open": "(", "close": ")" },
        { "open": "<", "close": ">" },
        { "open": "\"", "close": "\"", "notIn": ["string"] },
+       { "open": "'", "close": "'", "notIn": ["string"]},
        { "open": "/**", "close": " */", "notIn": ["string"] },
        { "open": "/*!", "close": " */", "notIn": ["string"] }
    ],


### PR DESCRIPTION
Because I felt inconvenient not to close a single quotation automatically, I added the rule to `language-configuration.json`.

If there are some reasons why a single quote is not included in `autoClosingPairs`, please tell me about that.