### PR TITLE
Deprecate `rust-lang.rust`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Rust support for Visual Studio Code
+# Rust support for Visual Studio Code (deprecated)
 
 [![](https://vsmarketplacebadge.apphb.com/version/rust-lang.rust.svg)](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust)
 [![VSCode + Node.js CI](https://img.shields.io/github/workflow/status/rust-lang/rls-vscode/VSCode%20+%20Node.js%20CI.svg?logo=github)](https://github.com/rust-lang/rls-vscode/actions?query=workflow%3A%22VSCode+%2B+Node.js+CI%22)
+
+> Note: This extension has been deprecated in favor of the [rust-analyzer project](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).
 
 Adds language support for Rust to Visual Studio Code. Supports:
 

--- a/package.json
+++ b/package.json
@@ -485,6 +485,11 @@
                     ],
                     "default": null,
                     "description": "When specified, uses the rust-analyzer binary at a given path"
+                },
+                "rust-client.ignoreDeprecationWarning": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to surpress the deprecation notification on start up."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rust",
-    "displayName": "Rust",
+    "displayName": "Rust (deprecated)",
     "description": "Rust for Visual Studio Code (powered by Rust Language Server/Rust Analyzer). Provides lints, code completion and navigation, formatting and more.",
     "version": "0.7.8",
     "publisher": "rust-lang",

--- a/package.json
+++ b/package.json
@@ -486,7 +486,7 @@
                     "default": null,
                     "description": "When specified, uses the rust-analyzer binary at a given path"
                 },
-                "rust-client.ignoreDeprecationWarning": {
+                "rust.ignore_deprecation_warning": {
                     "type": "boolean",
                     "default": false,
                     "description": "Whether to surpress the deprecation notification on start up."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,17 @@ export interface Api {
 }
 
 export async function activate(context: ExtensionContext): Promise<Api> {
+  await window.showWarningMessage(
+    "rust-lang.rust has been deprecated. Please uninstall this extension and install rust-lang.rust-analyzer instead. You can find the extension by clicking on one of the buttons",
+    "Open in your browser", "Open in a new editor tab"
+  ).then(button => {
+    commands.executeCommand(
+      'vscode.open',
+      button == "Open browser"
+        ? Uri.parse('https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer')
+        : Uri.parse("vscode:extension/rust-lang.rust-analyzer")
+    );
+  });
   context.subscriptions.push(
     ...[
       configureLanguage(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,17 +32,22 @@ export interface Api {
 }
 
 export async function activate(context: ExtensionContext): Promise<Api> {
-  await window.showWarningMessage(
-    "rust-lang.rust has been deprecated. Please uninstall this extension and install rust-lang.rust-analyzer instead. You can find the extension by clicking on one of the buttons",
-    "Open in your browser", "Open in a new editor tab"
-  ).then(button => {
-    commands.executeCommand(
-      'vscode.open',
-      button == "Open browser"
-        ? Uri.parse('https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer')
-        : Uri.parse("vscode:extension/rust-lang.rust-analyzer")
-    );
-  });
+  await window
+    .showWarningMessage(
+      'rust-lang.rust has been deprecated. Please uninstall this extension and install rust-lang.rust-analyzer instead. You can find the extension by clicking on one of the buttons',
+      'Open in your browser',
+      'Open in a new editor tab',
+    )
+    .then(button => {
+      commands.executeCommand(
+        'vscode.open',
+        button === 'Open browser'
+          ? Uri.parse(
+              'https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer',
+            )
+          : Uri.parse('vscode:extension/rust-lang.rust-analyzer'),
+      );
+    });
   context.subscriptions.push(
     ...[
       configureLanguage(),


### PR DESCRIPTION
Adds a notice to the extension name and readme as well as triggering a notification pop on start linking to the rust-analyzer marketplace pages.

![image](https://user-images.githubusercontent.com/3757771/170244143-2a41e5de-c4c9-4ba5-b8d2-013282081e8f.png)

cc https://github.com/rust-lang/rls/pull/1776
