### PR TITLE
Bump version in preparation for the last release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 [![](https://vsmarketplacebadge.apphb.com/version/rust-lang.rust.svg)](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust)
 [![VSCode + Node.js CI](https://img.shields.io/github/workflow/status/rust-lang/rls-vscode/VSCode%20+%20Node.js%20CI.svg?logo=github)](https://github.com/rust-lang/rls-vscode/actions?query=workflow%3A%22VSCode+%2B+Node.js+CI%22)
 
-> Note: This extension has been deprecated in favor of the [rust-analyzer project](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).
+----
+
+> **Warning**
+> # This extension is no longer maintained.
+> This has been replaced by the [**rust-analyzer extension**](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).
+
+-----
 
 Adds language support for Rust to Visual Studio Code. Supports:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "rust",
-    "version": "0.7.8",
+    "version": "0.7.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "rust",
     "displayName": "Rust (deprecated)",
     "description": "Rust for Visual Studio Code (powered by Rust Language Server/Rust Analyzer). Provides lints, code completion and navigation, formatting and more.",
-    "version": "0.7.8",
+    "version": "0.7.9",
     "publisher": "rust-lang",
     "icon": "icon.png",
     "galleryBanner": {


### PR DESCRIPTION
This bumps the version in preparation for the last release. This should include #956, and will also present a notice on the README (and thus the Marketplace) that this shouldn't be used.
